### PR TITLE
Move requirements to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests
+.

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ from setuptools import setup, find_packages
 
 NAME = 'tinycards'
 
-requirements = list(open('requirements.txt', 'r').readlines())
-
 setup(
     name=NAME,
     version='0.21',
@@ -13,7 +11,9 @@ setup(
     author_email='florian.joh.schaefer@gmail.com',
     license='MIT',
     packages=find_packages(),
-    install_requires=requirements,
+    install_requires=[
+        'requests',
+    ],
     zip_safe=False,
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
I couldn't install this library from PyPi, because for some reason `requirements.txt` is not in the tarball:
```console
$ pip install --user tinycards==0.21  
Collecting tinycards==0.21
  Using cached https://files.pythonhosted.org/packages/cf/c1/f26b5805610f3ad5601c893289f28c081c1c6339251c94be1d98dba96947/tinycards-0.21.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-trhfbk0v/tinycards/setup.py", line 5, in <module>
        requirements = list(open('requirements.txt', 'r').readlines())
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-trhfbk0v/tinycards/
```

[This answer on stackoverflow](https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py) recommends putting dependencies into `setup.py`, and reference that from `requirements.txt` with a `.`.

I think this should fix it? But I've never done this, so let me know if I got something wrong.