### PR TITLE
Fix issue with attempting to call a dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - '3.6'
 install:
   - pip install -e .
-  - pip install pytest pytest-cov
+  - pip install pytest 
+  - pip install 'pytest-cov>=2.4.0,<2.6'
   - pip install coveralls
 script:
   - pytest --cov tinycards

--- a/tinycards/networking/json_converter.py
+++ b/tinycards/networking/json_converter.py
@@ -9,11 +9,11 @@ from tinycards.model import User
 def json_to_user(json_data):
     """Convert a JSON dict into a User object."""
     user_obj = User(
-        creation_date=json_data.get('creationDate'),
-        email=json_data.get('email'),
-        fullname=json_data.get('fullname'),
+        creation_date=json_data['creationDate'],
+        email=json_data['email'],
+        fullname=json_data.get['fullname'],
         user_id=json_data['id'],
-        learning_language=json_data('learningLanguage'),
+        learning_language=json_data['learningLanguage'],
         picture_url=json_data['picture'],
         subscribed=json_data['subscribed'],
         subscriber_count=json_data['subscriberCount'],

--- a/tinycards/networking/json_converter.py
+++ b/tinycards/networking/json_converter.py
@@ -11,7 +11,7 @@ def json_to_user(json_data):
     user_obj = User(
         creation_date=json_data['creationDate'],
         email=json_data['email'],
-        fullname=json_data.get['fullname'],
+        fullname=json_data['fullname'],
         user_id=json_data['id'],
         learning_language=json_data['learningLanguage'],
         picture_url=json_data['picture'],


### PR DESCRIPTION
This fixes an issue in json_to_user() where it attempts to call json_data():
`learning_language=json_data('learningLanguage'),`

This will fail as json_data is a dict and not callable.
Additionally - I've moved all the get() methods to addressing the keys directly for consistency.