### PR TITLE
Make Card and Deck classes accessible from module level

### DIFF
--- a/tinycards/__init__.py
+++ b/tinycards/__init__.py
@@ -1,1 +1,4 @@
 from tinycards.client import Tinycards
+from tinycards.model import Card, Deck
+
+__all__ = ['Card', 'Deck', 'Tinycards']


### PR DESCRIPTION
Since *Card* and *Deck* can be expected to be the most used model classes, those two are made available from the module level.