### PR TITLE
Fix user ID usage

### DIFF
--- a/tinycards/model/card.py
+++ b/tinycards/model/card.py
@@ -21,12 +21,10 @@ class Card(object):
     def __init__(self,
                  front,
                  back,
-                 user_id=None,
                  card_id=None,
                  creation_timestamp=None):
         """Initialize a new instance of the Card class."""
         self.id = card_id if card_id else str(uuid4())
-        self.user_id = user_id
 
         self.creation_timestamp = creation_timestamp or current_timestamp()
 
@@ -36,15 +34,13 @@ class Card(object):
         if isinstance(front, Side):
             self.front = front
         elif isinstance(front, str):
-            self.front = Side(concepts=Concept(Fact(front), self.user_id),
-                              user_id=self.user_id)
+            self.front = Side(concepts=Concept(Fact(front)))
         else:
             raise ValueError("Front property can only be of type Side")
         if isinstance(back, Side):
             self.back = back
         elif isinstance(back, str):
-            self.back = Side(concepts=Concept(Fact(back), self.user_id),
-                             user_id=self.user_id)
+            self.back = Side(concepts=Concept(Fact(back)))
         else:
             raise ValueError("Back property can only be of type Side")
 

--- a/tinycards/model/concept.py
+++ b/tinycards/model/concept.py
@@ -7,13 +7,11 @@ class Concept(object):
 
     def __init__(self,
                  fact,
-                 user_id,
                  concept_id=None,
                  creation_timestamp=None,
                  update_timestamp=None):
         """Initialize a new instance of the Concept class."""
         self.fact = fact
-        self.user_id = user_id
         self.id = concept_id if concept_id else str(uuid4())
         self.creation_timestamp = (creation_timestamp if creation_timestamp
                                    else time())

--- a/tinycards/model/deck.py
+++ b/tinycards/model/deck.py
@@ -45,7 +45,6 @@ class Deck(object):
         '''
         # IDs:
         self.id = deck_id
-        self.user_id = None
         self.slug = slug
         self.compact_id = compact_id
 
@@ -69,11 +68,7 @@ class Deck(object):
     def add_card(self, card):
         """Add a new card to the deck."""
         if isinstance(card, tuple) and len(card) == 2:
-            new_card = Card(
-                front=card[0],
-                back=card[1],
-                user_id=self.user_id
-            )
+            new_card = Card(front=card[0], back=card[1])
         else:
             raise ValueError("Invalid card used as argument")
         self.cards.append(new_card)

--- a/tinycards/model/side.py
+++ b/tinycards/model/side.py
@@ -7,12 +7,10 @@ class Side(object):
     """"Data class for an Tinycards side entity."""
 
     def __init__(self,
-                 user_id,
                  side_id=None,
                  concepts=None):
         """Initialize a new instance of the Side class."""
         self.side_id = side_id if side_id else str(uuid4())
-        self.user_id = user_id
         if isinstance(concepts, Concept):
             self.concepts = [concepts]
         elif isinstance(concepts, list):

--- a/tinycards/networking/json_converter.py
+++ b/tinycards/networking/json_converter.py
@@ -57,7 +57,6 @@ def json_to_concept(json_data):
     """Convert a JSON dict into a Concept object."""
     concept_obj = Concept(
         fact=json_to_fact(json_data['fact']),
-        user_id=json_data['userId'],
         concept_id=json_data['id'],
         creation_timestamp=json_data['createdAt'],
         update_timestamp=json_data['updatedAt']
@@ -74,7 +73,6 @@ def concept_to_json(concept_obj):
         # 'id': concept_obj.id,
         # 'noteFacts': [],
         # 'updatedAt': concept_obj.update_timestamp,
-        # 'userId': concept_obj.user_id
     }
 
     return json_data
@@ -86,7 +84,6 @@ def json_to_side(json_data):
     """Convert a JSON dict into a Side object."""
     side_obj = Side(
         side_id=json_data['id'],
-        user_id=json_data['userId'],
         concepts=[json_to_concept(c) for c in json_data['concepts']]
     )
 
@@ -98,7 +95,6 @@ def side_to_json(side_obj):
     json_data = {
         'concepts': [concept_to_json(c) for c in side_obj.concepts],
         # 'id': side_obj.side_id,
-        # 'userId': side_obj.user_id
     }
 
     return json_data
@@ -111,7 +107,6 @@ def json_to_card(json_data):
     card_obj = Card(
         front=json_to_side(json_data['sides'][0]),
         back=json_to_side(json_data['sides'][1]),
-        user_id=json_data['userId'],
         card_id=json_data['id']
     )
 
@@ -127,7 +122,6 @@ def card_to_json(card_obj):
             side_to_json(card_obj.front),
             side_to_json(card_obj.back)
         ],
-        # 'userId': card_obj.user_id
     }
 
     # Add additional fields if not None.
@@ -259,7 +253,6 @@ def trendable_to_json(trendable_obj: Trendable):
         'ttsLanguages': trendable_data.tts_languages,
         'uiLanguage': trendable_data.ui_language,
         'updatedAt': trendable_data.updated_at,
-        'userId': trendable_data.user_id,
         'username': trendable_data.username
     }
 


### PR DESCRIPTION
As discussed [here](https://github.com/floscha/tinycards-python-api/issues/51#issuecomment-473450656) in #51, the user ID is passed down many objects of the Tinycards model even though it is in fact always `None` and not used anywhere. This PR consequentially removes all unnecessary instances of `user_id`.