### PR TITLE
Add linter to CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - pip install -e .
   - pip install -r test-requirements.txt
 script:
+  - pylama tinycards tests
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]];
     then pytest --cov tinycards;
     else pytest --ignore tests/client_test.py

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 coveralls==1.5.1
+pylama==7.6.6
 pytest==4.1.1
 pytest-cov==2.6.1


### PR DESCRIPTION
Add the *pylama* linter to the CI pipeline to check for linting issues before running the unit tests.